### PR TITLE
Fix/theme flicker

### DIFF
--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -47,7 +47,7 @@ export function ThemeProvider({
 				? "dark"
 				: "light";
 			root.classList.add(systemTheme);
-			setThemeCookie(storageKey, "system");
+			setThemeCookie(storageKey, systemTheme); // Store the resolved theme
 		} else {
 			root.classList.add(theme);
 			setThemeCookie(storageKey, theme);

--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -3,7 +3,7 @@
 import { getThemeCookie, setThemeCookie } from "@/app/lib/actions";
 import React from "react";
 
-type Theme = "dark" | "light" | "system";
+export type Theme = "dark" | "light" | "system";
 
 type ThemeProviderProps = {
 	children: React.ReactNode;
@@ -33,18 +33,9 @@ export function ThemeProvider({
 	const [theme, setThemeState] = React.useState<Theme>(defaultTheme);
 
 	React.useEffect(() => {
-		const fetchInitialTheme = async () => {
-			const cookieTheme = await getThemeCookie(storageKey);
-			if (cookieTheme && ["dark", "light", "system"].includes(cookieTheme)) {
-				setThemeState(cookieTheme as Theme);
-			} else {
-				// If no cookie or invalid, set to default.
-				// The next effect will persist it if it's not 'system'.
-				setThemeState(defaultTheme);
-			}
-		};
-		fetchInitialTheme();
-	}, [storageKey, defaultTheme]);
+		// Initialize theme state with defaultTheme passed from the server
+		setThemeState(defaultTheme);
+	}, [defaultTheme]); // Re-run if defaultTheme changes
 
 	React.useEffect(() => {
 		const root = window.document.documentElement;

--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getThemeCookie, setThemeCookie } from "@/app/lib/actions";
+import { setThemeCookie } from "@/app/lib/actions";
 import React from "react";
 
 export type Theme = "dark" | "light" | "system";

--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -27,15 +27,14 @@ const ThemeProviderContext =
 export function ThemeProvider({
 	children,
 	defaultTheme = "system",
-	storageKey = "vite-ui-theme",
+	storageKey = "theme",
 	...props
 }: ThemeProviderProps) {
 	const [theme, setThemeState] = React.useState<Theme>(defaultTheme);
 
 	React.useEffect(() => {
-		// Initialize theme state with defaultTheme passed from the server
 		setThemeState(defaultTheme);
-	}, [defaultTheme]); // Re-run if defaultTheme changes
+	}, [defaultTheme]);
 
 	React.useEffect(() => {
 		const root = window.document.documentElement;
@@ -47,7 +46,7 @@ export function ThemeProvider({
 				? "dark"
 				: "light";
 			root.classList.add(systemTheme);
-			setThemeCookie(storageKey, systemTheme); // Store the resolved theme
+			setThemeCookie(storageKey, systemTheme);
 		} else {
 			root.classList.add(theme);
 			setThemeCookie(storageKey, theme);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import { SpeedInsights } from "@vercel/speed-insights/next";
-import { ThemeProvider, type Theme } from "./components/theme-provider";
 import { getThemeCookie } from "@/app/lib/actions";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+import { type Theme, ThemeProvider } from "./components/theme-provider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -26,7 +26,11 @@ export default async function RootLayout({
 }>) {
 	const cookieTheme = await getThemeCookie("vite-ui-theme");
 	let initialTheme: Theme;
-	if (cookieTheme === "dark" || cookieTheme === "light" || cookieTheme === "system") {
+	if (
+		cookieTheme === "dark" ||
+		cookieTheme === "light" ||
+		cookieTheme === "system"
+	) {
 		initialTheme = cookieTheme;
 	} else {
 		initialTheme = "system";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	const cookieTheme = await getThemeCookie("vite-ui-theme");
+	const cookieTheme = await getThemeCookie("theme");
 	let initialTheme: Theme;
 	if (
 		cookieTheme === "dark" ||

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,8 @@ import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import { ThemeProvider } from "./components/theme-provider";
+import { ThemeProvider, type Theme } from "./components/theme-provider";
+import { getThemeCookie } from "@/app/lib/actions";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,15 +19,26 @@ export const viewport: Viewport = {
 	userScalable: false,
 };
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
+	const cookieTheme = await getThemeCookie("vite-ui-theme");
+	let initialTheme: Theme;
+	if (cookieTheme === "dark" || cookieTheme === "light" || cookieTheme === "system") {
+		initialTheme = cookieTheme;
+	} else {
+		initialTheme = "system";
+	}
+	let htmlClassName = inter.className;
+	if (initialTheme === "dark" || initialTheme === "light") {
+		htmlClassName = `${inter.className} ${initialTheme}`;
+	}
 	return (
-		<html lang="en" suppressHydrationWarning>
+		<html lang="en" suppressHydrationWarning className={htmlClassName}>
 			<body className={inter.className}>
-				<ThemeProvider defaultTheme="system">{children}</ThemeProvider>
+				<ThemeProvider defaultTheme={initialTheme}>{children}</ThemeProvider>
 				<SpeedInsights />
 			</body>
 		</html>

--- a/app/ui/skeletons.tsx
+++ b/app/ui/skeletons.tsx
@@ -41,7 +41,7 @@ export function ContractMobileSkeleton({
 				<div
 					// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
 					key={index}
-					className="mb-2 w-full rounded-md bg-white dark:bg-slate-600 p-4 shadow-md"
+					className="mb-2 w-full rounded-md bg-white dark:bg-secondary/80 p-4 shadow-md"
 				>
 					<div className="flex items-center justify-between border-b pb-4">
 						<div>


### PR DESCRIPTION
Fix an issue causing theme flickering whereby a light theme would first render and then switch to the right one.
- This now server renders the right theme as it's persisted in cookies for the server component to access.
- Fix a color shift during loading for mobile table view.